### PR TITLE
Remove usefull function on AParser and IParser class

### DIFF
--- a/src/Parser/AParser.cpp
+++ b/src/Parser/AParser.cpp
@@ -7,30 +7,6 @@
 
 #include "AParser.hpp"
 
-void AParser::setCommand(const std::string &command)
-{
-    std::string tmpCommand = command;
-
-    _command = command;
-    while (!tmpCommand.empty()) {
-        while (tmpCommand.find(_separator) == 0)
-            tmpCommand = tmpCommand.substr(1);
-        if (tmpCommand.empty())
-            break;
-        _arguments.push_back(tmpCommand.substr(0, tmpCommand.find(_separator)));
-        if (tmpCommand.find(_separator) < tmpCommand.size())
-            tmpCommand = tmpCommand.substr(tmpCommand.find(_separator));
-        else
-            tmpCommand.clear();
-        _argumentNumber++;
-    }
-}
-
-const std::string &AParser::getCommand() const
-{
-    return (_command);
-}
-
 const std::size_t &AParser::getArgumentNumber() const
 {
     return (_argumentNumber);

--- a/src/Parser/AParser.cpp
+++ b/src/Parser/AParser.cpp
@@ -12,11 +12,6 @@ const std::size_t &AParser::getArgumentNumber() const
     return (_argumentNumber);
 }
 
-void AParser::setCommandSeparator(char separator)
-{
-    _separator = separator;
-}
-
 const std::vector<std::string> &AParser::getArguments() const
 {
     return (_arguments);

--- a/src/Parser/AParser.hpp
+++ b/src/Parser/AParser.hpp
@@ -28,8 +28,6 @@ class AParser : public IParser {
         const std::vector<std::string> &getArguments() const;
 
     protected:
-        /// \brief Store the command that will be prossess.
-        std::string _command;
         /// \brief Store the number of arguments in the command.
         std::size_t _argumentNumber;
         /// \brief Store the separator of each argument.

--- a/src/Parser/AParser.hpp
+++ b/src/Parser/AParser.hpp
@@ -15,13 +15,6 @@ class AParser : public IParser {
     public:
         /// \brief Destroy the AParser object as default.
         ~AParser() = default;
-        /// \brief Set the command that will be parsed.
-        /// \param const std::string & is the command string
-        void setCommand(const std::string &);
-        /// \brief Get the command previously set.
-        /// \return const std::string& of the command.
-        /// It return an empty std::string in case of undefined command.
-        const std::string &getCommand() const;
         /// \brief Get the number of arguments in the command.
         /// \return const std::size_t&, the number of arguments.
         const std::size_t &getArgumentNumber() const;

--- a/src/Parser/AParser.hpp
+++ b/src/Parser/AParser.hpp
@@ -20,9 +20,6 @@ class AParser : public IParser {
         const std::size_t &getArgumentNumber() const;
         /// \brief This function will be set differently by the children
         virtual void prossessArguments() = 0;
-        /// \brief Set a char that will be the separator on each command.
-        /// \param char of the separator
-        void setCommandSeparator(char);
         /// \brief Get the a list of all arguments in the command.
         /// \return const std::vector<std::string>& that contain each argument.
         const std::vector<std::string> &getArguments() const;
@@ -30,8 +27,6 @@ class AParser : public IParser {
     protected:
         /// \brief Store the number of arguments in the command.
         std::size_t _argumentNumber;
-        /// \brief Store the separator of each argument.
-        char _separator;
         /// \brief Store a vector of all argument.
         std::vector<std::string> _arguments;
 };

--- a/src/Parser/IParser.hpp
+++ b/src/Parser/IParser.hpp
@@ -21,9 +21,6 @@ class IParser {
         virtual const std::size_t &getArgumentNumber() const = 0;
         /// \brief This function will be set differently by the children
         virtual void prossessArguments() = 0;
-        /// \brief Set a char that will be the separator on each command.
-        /// \param char of the separator
-        virtual void setCommandSeparator(char) = 0;
         /// \brief Get the a list of all arguments in the command.
         /// \return const std::vector<std::string>& that contain each argument.
         virtual const std::vector<std::string> &getArguments() const = 0;

--- a/src/Parser/IParser.hpp
+++ b/src/Parser/IParser.hpp
@@ -16,13 +16,6 @@ class IParser {
     public:
         /// \brief Destroy the IParser object as default
         ~IParser() = default;
-        /// \brief Set the command that will be parsed.
-        /// \param const std::string & is the command string
-        virtual void setCommand(const std::string &) = 0;
-        /// \brief Get the command previously set.
-        /// \return const std::string& of the command.
-        /// It return an empty std::string in case of undefined command.
-        virtual const std::string &getCommand() const = 0;
         /// \brief Get the number of arguments in the command.
         /// \return const std::size_t&, the number of arguments.
         virtual const std::size_t &getArgumentNumber() const = 0;


### PR DESCRIPTION
Remove useless function on AParser and IParser class:
- getCommand
- setCommand
- setCommandSeparator
Remove useless variable on AParser and IParser class:
- _command
- _separator
They are usefull for only one child (InputParser)