### PR TITLE
Using the parameter argc instead of calculating the size of the vector arguments

### DIFF
--- a/src/Parser/ArgumentsParser/ArgumentsParser.cpp
+++ b/src/Parser/ArgumentsParser/ArgumentsParser.cpp
@@ -10,12 +10,12 @@
 #include "ArgumentsParser.hpp"
 #include <iostream>
 
-ArgumentsParser::ArgumentsParser(char **args)
+ArgumentsParser::ArgumentsParser(int ac, char **args)
 {
     for (size_t x = 0; args[x]; ++x) {
         _arguments.push_back(std::string(args[x]));
     }
-    _argumentNumber = _arguments.size();
+    _argumentNumber = ac;
 }
 
 void ArgumentsParser::prossessArguments()

--- a/src/Parser/ArgumentsParser/ArgumentsParser.hpp
+++ b/src/Parser/ArgumentsParser/ArgumentsParser.hpp
@@ -15,8 +15,10 @@
 /// \brief ArgumentsParser class define functions for parsing received arguments
 class ArgumentsParser : public AParser {
     public:
-        /// \brief Construct the ArgumentsParser with the received arguments without the binary name (argv + 1)
-        ArgumentsParser(char ** = nullptr);
+        /// \brief Construct the ArgumentsParser with the received arguments
+        /// \param ac number of arguments without the binary name (ac - 1)
+        /// \param av arguments tab without the binary name (av + 1)
+        ArgumentsParser(int = 0, char ** = nullptr);
         /// \brief Destroy the ArgumentsParser object as default.
         ~ArgumentsParser() = default;
         /// \brief Get the cooking Time for the Plazza

--- a/src/Parser/ArgumentsParser/ArgumentsParser.hpp
+++ b/src/Parser/ArgumentsParser/ArgumentsParser.hpp
@@ -15,10 +15,12 @@
 /// \brief ArgumentsParser class define functions for parsing received arguments
 class ArgumentsParser : public AParser {
     public:
+        /// \brief Default Constructor of the ArgumentsParser DO NOT USE
+        ArgumentsParser();
         /// \brief Construct the ArgumentsParser with the received arguments
         /// \param ac number of arguments without the binary name (ac - 1)
         /// \param av arguments tab without the binary name (av + 1)
-        ArgumentsParser(int = 0, char ** = nullptr);
+        ArgumentsParser(int, char **);
         /// \brief Destroy the ArgumentsParser object as default.
         ~ArgumentsParser() = default;
         /// \brief Get the cooking Time for the Plazza

--- a/src/Parser/ArgumentsParser/ArgumentsParser.hpp
+++ b/src/Parser/ArgumentsParser/ArgumentsParser.hpp
@@ -16,7 +16,7 @@
 class ArgumentsParser : public AParser {
     public:
         /// \brief Default Constructor of the ArgumentsParser DO NOT USE
-        ArgumentsParser();
+        ArgumentsParser() = default;
         /// \brief Construct the ArgumentsParser with the received arguments
         /// \param ac number of arguments without the binary name (ac - 1)
         /// \param av arguments tab without the binary name (av + 1)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,7 +10,7 @@
 
 int main(int ac, char **av)
 {
-    ArgumentsParser args(av + 1);
+    ArgumentsParser args(ac - 1, av + 1);
 
     args.prossessArguments();
     return 0;


### PR DESCRIPTION
In the ArgumentsParser Class, add a parameter to the constructor (argc) to directly have the arguments number to avoid calculating it